### PR TITLE
added a workaround which allows to remove `size(const T (&a)[0])`

### DIFF
--- a/arrayutils.h
+++ b/arrayutils.h
@@ -65,7 +65,7 @@ public:
 	 * @return 0
 	 */
 	template<typename T>
-	static size_t size(const T (&a)[0])
+	static size_t size(const T*)
 	{
 		return 0;
 	}
@@ -79,7 +79,8 @@ public:
 	 *  static arrays and can be used with automatic template argument deduction.
 	 */
 	template<typename T>
-	static size_t size(const T &a)
+	static typename std::enable_if<utils::has_size<T>::value, size_t>::type
+	size(const T &a)
 	{
 		return a.size();
 	}

--- a/arrayutils.h
+++ b/arrayutils.h
@@ -37,6 +37,8 @@
 #ifndef UTILS_ARRAYUTILS_H
 #define UTILS_ARRAYUTILS_H
 
+#include "common.h"
+
 namespace utils
 {
 
@@ -79,7 +81,7 @@ public:
 	 *  static arrays and can be used with automatic template argument deduction.
 	 */
 	template<typename T>
-	static typename std::enable_if<utils::has_size<T>::value, size_t>::type
+	static typename std::enable_if<has_size<T>::value, size_t>::type
 	size(const T &a)
 	{
 		return a.size();

--- a/common.h
+++ b/common.h
@@ -48,6 +48,13 @@ void swap(T& a, T& b)
 	b = tmp;
 }
 
+template<typename T>
+struct has_size {
+	template<typename U> static constexpr decltype(std::declval<U>().size(), bool()) test(int) { return true; }
+	template<typename U> static constexpr bool test(...) { return false; }
+	static constexpr bool value = test<T>(int());
+};
+
 }
 
 #endif // UTILS_COMMON_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set( CMAKE_MODULE_PATH
 	${CMAKE_SOURCE_DIR}/submodules/cxxtest/build_tools/cmake
 	${CMAKE_MODULE_PATH} )
 
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-pedantic -Werror")
 # Get cxxtest
 # TODO support installations without cxxtest
 find_package( CxxTest REQUIRED )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ set( CMAKE_MODULE_PATH
 	${CMAKE_SOURCE_DIR}/submodules/cxxtest/build_tools/cmake
 	${CMAKE_MODULE_PATH} )
 
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-pedantic -Werror")
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-pedantic -Werror -std=c++14")
 # Get cxxtest
 # TODO support installations without cxxtest
 find_package( CxxTest REQUIRED )

--- a/tests/arrayutils.t.h
+++ b/tests/arrayutils.t.h
@@ -53,7 +53,10 @@ public:
 		int a1[] = {1, 2, 3, 4, 5, 6};
 		TS_ASSERT_EQUALS(ArrayUtils::size(a1), 6);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 		int a2[0];
+#pragma GCC diagnostic pop
 		TS_ASSERT_EQUALS(ArrayUtils::size(a2), 0);
 
 		std::vector<char> a3;


### PR DESCRIPTION
This PR is addressed to remove GCC compiler warnings caused by array zero initialization