### PR TITLE
Remove cxxtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/cxxtest"]
-	path = submodules/cxxtest
-	url = https://github.com/CxxTest/cxxtest.git


### PR DESCRIPTION
Remove cxxtest; it's normally better to install it on-demand for the CI anyways.
(right now, it causes a lot of recursive dependency loading in SeisSol)