### PR TITLE
Localize environment variable reader

### DIFF
--- a/env.h
+++ b/env.h
@@ -23,13 +23,16 @@ namespace utils {
  */
 class Env {
   private:
-  static inline std::unordered_map<std::string, std::optional<std::string>> cache;
+  std::string prefix;
+  std::unordered_map<std::string, std::optional<std::string>> cache;
 
   public:
+  Env(const std::string& prefix) : prefix(prefix) {}
+
   template <typename T>
-  static auto getOptional(const std::string& name) -> std::optional<T> {
+  auto getOptional(const std::string& name) -> std::optional<T> {
     if (cache.find(name) == cache.end()) {
-      char* value = std::getenv(name.c_str());
+      char* value = std::getenv((prefix + name).c_str());
       if (value == nullptr) {
         cache[name] = std::optional<std::string>();
       } else {
@@ -46,7 +49,7 @@ class Env {
   }
 
   template <typename T>
-  static auto get(const std::string& name, T&& defaultVal)
+  auto get(const std::string& name, T&& defaultVal)
       -> std::enable_if_t<!std::is_array_v<T>, std::decay_t<T>> {
     // mirror requirements for an optional
     const auto value = getOptional<std::decay_t<T>>(name);
@@ -59,7 +62,7 @@ class Env {
   }
 
   template <typename T>
-  static auto get(const std::string& name, const T* defaultVal)
+  auto get(const std::string& name, const T* defaultVal)
       -> std::enable_if_t<std::is_convertible_v<T*, std::string>, std::string> {
     const auto value = getOptional<std::string>(name);
 

--- a/progress.h
+++ b/progress.h
@@ -53,9 +53,11 @@ class Progress {
   /** TTY handle (if used) */
   std::ofstream m_tty;
 
+  Env env{"UTILS_PROGRESS_"};
+
   public:
   Progress(unsigned long total = 100) {
-    std::string envOutput = Env::get<std::string>("UTILS_PROGRESS_OUTPUT", "STDERR");
+    std::string envOutput = env.get<std::string>("OUTPUT", "STDERR");
 
     StringUtils::toUpper(envOutput);
 
@@ -172,7 +174,7 @@ class Progress {
    */
   void setSize(bool automatic = true) {
     // Check if size is set in env
-    const unsigned long size = Env::get<unsigned long>("UTILS_PROGRESS_SIZE", 0);
+    const auto size = env.get<unsigned long>("SIZE", 0);
 
     if (size > 0) {
       m_barSize = size;

--- a/tests/env.t.h
+++ b/tests/env.t.h
@@ -17,15 +17,16 @@ using namespace utils;
 class TestEnv : public CxxTest::TestSuite {
   public:
   static void testGet() {
+    Env env("UTILS_");
     TS_ASSERT_EQUALS(setenv("UTILS_INT", "42", 1), 0);
-    TS_ASSERT_EQUALS(Env::get<int>("UTILS_INT", 0), 42);
-    TS_ASSERT_EQUALS(Env::get("UTILS_INT", "0"), std::string("42"));
-    TS_ASSERT_EQUALS(Env::get<int>("UTILS_INT2", 3), 3);
+    TS_ASSERT_EQUALS(env.get<int>("INT", 0), 42);
+    TS_ASSERT_EQUALS(env.get("INT", "0"), std::string("42"));
+    TS_ASSERT_EQUALS(env.get<int>("INT2", 3), 3);
 
     TS_ASSERT_EQUALS(setenv("UTILS_BOOL", "1", 1), 0);
-    TS_ASSERT_EQUALS(Env::get<bool>("UTILS_BOOL", false), true);
+    TS_ASSERT_EQUALS(env.get<bool>("BOOL", false), true);
     TS_ASSERT_EQUALS(setenv("UTILS_BOOL2", "0", 1), 0);
-    TS_ASSERT_EQUALS(Env::get<bool>("UTILS_BOOL2", false), false);
+    TS_ASSERT_EQUALS(env.get<bool>("BOOL2", false), false);
   }
 };
 #endif // UTILS_TESTS_ENV_T_H_


### PR DESCRIPTION
Remove the `static inline` part which has been causing troubles with ICC/ICX.

Instead, allow for a prefix to be chosen for a local env object.
